### PR TITLE
[fix] #78 reconfiguring push_to_ecr.sh

### DIFF
--- a/push_to_ecr.sh
+++ b/push_to_ecr.sh
@@ -2,14 +2,27 @@
 
 ECR_URL="$1"
 NEW_VERSION="$2"
+PREFIX="spring-chatting-server_"
+
+
+echo "ECR_URL: $ECR_URL"
+echo "NEW_VERSION: $NEW_VERSION"
+echo "Push to AWS-ECR start"
+echo "Get docker images with spring-chatting-server prefix"
 
 # get list of images with spring-chatting-server prefix
-images=$(docker images --format "{{.Repository}}" | grep "^spring-chatting-server_" | grep -v "$ECR_URL")
+images=$(docker images --format "{{.Repository}}" | grep "^${PREFIX}")
+
+echo "${images}"
 
 # tagging and push to ECR
 for image in $images; do
+  # Use only image name without prefix
   IMAGE_NAME=$(echo "$image" | cut -d'_' -f2)_
+  echo "tagging ${image} to ${IMAGE_NAME}"
+
   ecr_image="$ECR_URL:$IMAGE_NAME$NEW_VERSION"
   docker tag "$image" "$ecr_image"
+  echo "push image to ECR with ${ecr_image}"
   docker push "$ecr_image"
 done


### PR DESCRIPTION
* Close #78 

## Description

* Edit `push_to_ecr.sh`

Originally, `push_to_ecr.sh` run `images=$(docker images --format "{{.Repository}}" | grep "^${PREFIX}" | grep ${ECR_URL})`. Here, our pre-build docker image names is defined as `spring-chatting-server_user-server` which is not containing ${ECR_URL}.

So we removing additional grep process `grep ${ECR_URL}`

* Changed `push_to_ecr.sh`
```bash
...
# get list of images with spring-chatting-server prefix
images=$(docker images --format "{{.Repository}}" | grep "^${PREFIX}")
...
```