### PR TITLE
[fix] adding export new_version but not in GITHUB_ENV

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -60,6 +60,7 @@ jobs:
           new_version="$major.$minor.$patch-$short_commit_hash"
           echo "Output [$new_version]"
           echo "NEW_VERSION=$new_version" >> $GITHUB_ENV
+          echo "NEW_VERSION=${NEW_VERSION}"
 
       - name: Create and push new tag to Github
         run: |


### PR DESCRIPTION
* change into raw export, not pass to `$GITHUB_ENV`