### PR TITLE
Feature/ecr token refresh scheduling

### DIFF
--- a/k8s/onlychat/deployment/chatting-server-deployment.yaml
+++ b/k8s/onlychat/deployment/chatting-server-deployment.yaml
@@ -19,9 +19,9 @@ spec:
             - name: SERVER_PORT
               value: "8030"
             - name: SPRING_CLOUD_CONFIG_URI
-              value: http://43.202.52.177:8888
+              value: "http://43.202.52.177:8888"
             - name: kafka_bootstrap
-              value: http://kafka1-service:9092
+              value: "http://kafka1-service:9092"
             - name: spring_autoconfigure_exclude
               value: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
             - name: spring_redis_host

--- a/k8s/onlychat/ecr-registry-token-refresh.yaml
+++ b/k8s/onlychat/ecr-registry-token-refresh.yaml
@@ -1,30 +1,30 @@
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: ecr-token-refresh
-spec:
-  schedule: "*/1 * * * *" # 1분마다 실행하도록 스케줄을 설정합니다.
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-            - name: ecr-token-refresh
-              image: amazon/aws-cli:latest # AWS CLI 이미지 사용
-              args:
-                - /bin/sh
-                - -c
-                - aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 305603388825.dkr.ecr.ap-northeast-2.amazonaws.com
-                - kubectl create secret generic ecr-cred --from-file=.dockerconfigjson=/root/.docker/config.json --type=kubernetes.io/dockerconfigjson
-              env:
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: ecr-cred
-                      key: AWS_ACCESS_KEY_ID
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ecr-cred
-                      key: AWS_SECRET_ACCESS_KEY
-          restartPolicy: OnFailure
+#apiVersion: batch/v1
+#kind: CronJob
+#metadata:
+#  name: ecr-token-refresh
+#spec:
+#  schedule: "*/1 * * * *" # 1분마다 실행하도록 스케줄을 설정합니다.
+#  jobTemplate:
+#    spec:
+#      template:
+#        spec:
+#          containers:
+#            - name: ecr-token-refresh
+#              image: amazon/aws-cli:latest # AWS CLI 이미지 사용
+#              args:
+#                - /bin/sh
+#                - -c
+#                - aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 305603388825.dkr.ecr.ap-northeast-2.amazonaws.com
+#                - kubectl create secret generic ecr-cred --from-file=.dockerconfigjson=/root/.docker/config.json --type=kubernetes.io/dockerconfigjson
+#              env:
+#                - name: AWS_ACCESS_KEY_ID
+#                  valueFrom:
+#                    secretKeyRef:
+#                      name: ecr-cred
+#                      key: AWS_ACCESS_KEY_ID
+#                - name: AWS_SECRET_ACCESS_KEY
+#                  valueFrom:
+#                    secretKeyRef:
+#                      name: ecr-cred
+#                      key: AWS_SECRET_ACCESS_KEY
+#          restartPolicy: OnFailure

--- a/spring-chatting-backend-server/build.gradle
+++ b/spring-chatting-backend-server/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.0.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
+	implementation 'io.opentelemetry:opentelemetry-api:1.26.0'
 	implementation 'org.springframework.boot:spring-boot-configuration-processor';
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'com.google.guava:guava:31.1-jre'


### PR DESCRIPTION
* Related #221 

## Description
* Change version of OpenTelemetry to v1.26.0 since some version has critical faults
* Temporary disabling cronJobs of ecr token refresh