### PR TITLE
[fix] #221 jdk version to amazoncorretto:17-alpine3.16-jdk

### DIFF
--- a/apigateway-service/Dockerfile
+++ b/apigateway-service/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /null
 

--- a/apigateway-service/build.gradle
+++ b/apigateway-service/build.gradle
@@ -81,7 +81,7 @@ task generateDockerfile {
 			println "Latest Path: \${projectPath}${latestJarFile.absolutePath.replace(project.projectDir.absolutePath, '')}"
 			def dockerfileContent =
 					"""
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /${group}
 

--- a/customer-service/Dockerfile
+++ b/customer-service/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /null
 

--- a/customer-service/build.gradle
+++ b/customer-service/build.gradle
@@ -98,7 +98,7 @@ task generateDockerfile {
             println "Latest Path: \${projectPath}${latestJarFile.absolutePath.replace(project.projectDir.absolutePath, '')}"
             def dockerfileContent =
                     """
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /${group}
 

--- a/discovery/Dockerfile
+++ b/discovery/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /null
 

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -74,7 +74,7 @@ task generateDockerfile {
             println "Latest Path: \${projectPath}${latestJarFile.absolutePath.replace(project.projectDir.absolutePath, '')}"
             def dockerfileContent =
                     """
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /${group}
 

--- a/shop-user-service/Dockerfile
+++ b/shop-user-service/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /null
 

--- a/shop-user-service/build.gradle
+++ b/shop-user-service/build.gradle
@@ -114,7 +114,7 @@ task generateDockerfile {
 			println "Latest Path: \${projectPath}${latestJarFile.absolutePath.replace(project.projectDir.absolutePath, '')}"
 			def dockerfileContent =
 					"""
-FROM openjdk:17-alpine
+FROM amazoncorretto:17-alpine3.16-jdk
 
 WORKDIR /${group}
 


### PR DESCRIPTION
* Close #221 

## Description
* Change jdk version of `apigateway`, `chatting-server`, `customer-server`, `user-server`, `discovery`, etc. from **`openjdk:17-alpine`** to **`amazoncorretto:17-alpine3.16-jdk`**