### PR TITLE
[fix] #274 change lb symbolic url path to absolute url path

### DIFF
--- a/apigateway-service/src/main/resources/application.yaml
+++ b/apigateway-service/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ spring:
       routes:
         # 세부기능
         - id: user-service
-          uri: lb://AUTH-SERVICE
+          uri: http://user-server-service:8000
           predicates:
             - Path=/user/actuator/**
             - Method=GET, POST
@@ -41,7 +41,7 @@ spring:
             - RewritePath=/user(?<segment>/?.*), $\{segment}
         # 로그인
         - id: user-service
-          uri: lb://USER-SERVICE
+          uri: http://user-server-service:8000
           predicates:
             - Path=/user/login
             - Method=POST
@@ -50,7 +50,7 @@ spring:
             - RewritePath=/user(?<segment>/?.*), $\{segment}
         # 회원가입
         - id: user-service
-          uri: lb://USER-SERVICE
+          uri: http://user-server-service:8000
           predicates:
             - Path=/user
             - Method=POST
@@ -58,7 +58,7 @@ spring:
             - RemoveRequestHeader=Cookie
         # 관리자 access
         - id: user-service
-          uri: lb://USER-SERVICE
+          uri: http://user-server-service:8000
           predicates:
             - Path=/user/admin/**
             - Method=GET, POST
@@ -66,14 +66,14 @@ spring:
             - RewritePath=/user(?<segment>/?.*), $\{segment}
         # 일반 사용자 access
         - id: user-service
-          uri: lb://USER-SERVICE
+          uri: http://user-server-service:8000
           predicates:
             - Path=/user/**
             - Method=GET, POST, DELETE
           filters:
             - RemoveRequestHeader=Cookie
         - id: chat-service
-          uri: lb://CHAT-SERVICE
+          uri: http://chatting-server-service:8030
           predicates:
             - Path=/chat/**
             - Method=POST, GET, DELETE

--- a/k8s/onlychat/service/user-server-service.yaml
+++ b/k8s/onlychat/service/user-server-service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: user-server-service
   name: user-server-service
+  namespace: default
 spec:
   ports:
     - name: http


### PR DESCRIPTION
* Related #274 

## Description
* Symbolic url path doesn't work in Kubernetes because they advertising their url path with deployment dns not service dns
  * Change to actual service name dns from symbolic path like `USER-SERVICE`