### PR TITLE
[performance] CPU 사용률 최적화 및 스케일업 쿨타임 60초 설정

### DIFF
--- a/k8s/onlychat/deployment/chatting-server-deployment.yaml
+++ b/k8s/onlychat/deployment/chatting-server-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: spring_config_activate_on-profile
               value: "prod"
             - name: spring_datasource_hikari_maximum-pool-size
-              value: "70"
+              value: "30"
             - name: spring_datasource_hikari_password
               valueFrom:
                 secretKeyRef:

--- a/k8s/onlychat/hpa/chatting-server-hpa.yaml
+++ b/k8s/onlychat/hpa/chatting-server-hpa.yaml
@@ -15,16 +15,16 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 50 # 원하는 CPU 사용률 목표 (50%)
+          averageUtilization: 30 # 원하는 CPU 사용률 목표 (30%)
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 300 # 스케일 다운 안정화 기간 (300초) 빠르게 스케일 업/다운을 하지 않도록 설정
+      stabilizationWindowSeconds: 300 # 스케일 다운하기 전 대기 시간 (300초)
       policies:
         - type: Pods
           value: 1
           periodSeconds: 60 # 매트릭 확인 주기 (60초)
     scaleUp:
-      stabilizationWindowSeconds: 300 # 스케일 업 안정화 기간
+      stabilizationWindowSeconds: 60 # 스케일 업하기 전 대기 시간 (60초)
       policies:
         - type: Pods
           value: 1

--- a/spring-chatting-backend-server/src/main/resources/application.yaml
+++ b/spring-chatting-backend-server/src/main/resources/application.yaml
@@ -8,14 +8,6 @@ spring:
     name: chat-service
   messages:
     basename: messages,errors
-  datasource:
-    # tomcat.jdbc.pool settings
-    tomcat:
-      max-active: 30
-      initial-size: 10
-      max-wait: 10000
-      remove-abandoned: true
-      remove-abandoned-timeout: 300
   jpa:
     database: postgresql
     database-platform: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
* hikariCP 30으로 HPA max-pod 3 * 30 = 90 + a 이 100 (chat-db-max-connection) 이하가 될 수 있도록 설정
* tomcatCP 설정 해제
* 스케일 아웃 하기 이전 대기시간 60초로 수정
* 채팅서버 HPA cpu 30% 설정