### PR TITLE
[performance] 톰켓 WS 설정 최적화

### DIFF
--- a/spring-chatting-backend-server/src/main/resources/application.yaml
+++ b/spring-chatting-backend-server/src/main/resources/application.yaml
@@ -43,12 +43,12 @@ server:
   error:
     include-stacktrace: never
   tomcat:
-    accept-count: 100
-    connection-timeout: 10s
-    max-threads: 100
-    min-spare-threads: 30
-    max-connections: 300
-    max-swallow-size: 2MB
+    accept-count: 100 # default 100
+    connection-timeout: 60s # default 60s
+    max-threads: 150 # default 200
+    min-spare-threads: 30 # default 10
+    max-connections: 8192 # default 8192 동시에 처리할 수 있는 최대 연결 수
+    max-swallow-size: 2MB # default 2MB
 
 
 eureka:


### PR DESCRIPTION
* 대기 큐 크기(accept-count) 100 -> 100
  * 유지
* 동시 연결 개수(max-connections) 100 -> 8192 
  * 현재 vuser 300 의 동시 연결 요청을 전송하기때문에 이를 고려하여 default 개수까지 증량
* 최대 스레드 풀 크기(max-threads) 100 -> 150 
  * 채팅서버 vcpu limit 1500m 이기때문에 각 코어당 * 100 하여 처리 1.5 * 100 = 150
  * 현재 대부분의 API 요청에서 i/o 작업을 하기 때문에 왠만하면 스레드를 늘리는 것이 좋습니다. 만약 cpu 소모량이 많다고 한다면 줄이는 것이 좋다고 합니다. 괜한 context switch 를 줄이는 것이 효율적이기 때문입니다.
* 연결 타임아웃(connection-timeout) 10s -> 60s
  * 현재 readinessProbe 타임아웃 설정이 60s 로 설정되어 있습니다. 이에 맞추어 오류를 줄이기 위해 60s 로 설정하는 것이 올바르다고 생각해서 변경하게 되었습니다.
* 항상 유지되는 최소 스레드 크기(min-spare-threads) 30 -> 30 
  * 유지