### PR TITLE
[performance] Chat Index Long 타입 변경

### DIFF
--- a/spring-chatting-backend-server/src/main/java/chatting/chat/domain/chat/api/ChatController.java
+++ b/spring-chatting-backend-server/src/main/java/chatting/chat/domain/chat/api/ChatController.java
@@ -78,7 +78,6 @@ public class ChatController {
      */
     private Chatting createChatting(Room room, User user, String msg) {
         Chatting chatting = new Chatting();
-        chatting.setId(UUID.randomUUID().toString());
         chatting.setRoom(room);
         chatting.setSendUser(user);
         chatting.setCreatedAt(LocalDateTime.now());

--- a/spring-chatting-backend-server/src/main/java/chatting/chat/domain/chat/entity/Chatting.java
+++ b/spring-chatting-backend-server/src/main/java/chatting/chat/domain/chat/entity/Chatting.java
@@ -17,7 +17,8 @@ import java.time.LocalDateTime;
 @Setter
 public class Chatting extends BaseTime {
     @Id
-    private String id;
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "chatting_seq")
+    private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ROOM_ID")
     private Room room;
@@ -28,7 +29,7 @@ public class Chatting extends BaseTime {
     private String message;
 
     @Builder
-    public Chatting(String id, Room room, User sendUser, String message, LocalDateTime createdAt) {
+    public Chatting(Long id, Room room, User sendUser, String message, LocalDateTime createdAt) {
         this.id = id;
         this.room = room;
         this.sendUser = sendUser;
@@ -46,7 +47,7 @@ public class Chatting extends BaseTime {
      */
     public ChatRequest.ChatRecordDTO toChatRecordDTO() {
         return ChatRequest.ChatRecordDTO.builder()
-                .id(this.id)
+                .id(String.valueOf(this.id))
                 .roomId(this.room.getRoomId())
                 .sendUserId(this.sendUser.getUserId())
                 .sendUserName(this.sendUser.getUserName())

--- a/spring-chatting-backend-server/src/main/java/chatting/chat/domain/chat/service/ChatService.java
+++ b/spring-chatting-backend-server/src/main/java/chatting/chat/domain/chat/service/ChatService.java
@@ -87,7 +87,6 @@ public class ChatService {
             .orElseThrow(() -> new CustomException(CANNOT_FIND_USER));
 
         Chatting chatting = Chatting.builder()
-            .id(UUID.randomUUID().toString())
             .room(room)
             .sendUser(user)
             .message(req.getMessage())


### PR DESCRIPTION
* Chatting 테이블의 id 타입을 Long sequence auto generation 으로 변경
> 이 후 b-tree 인덱싱에서 Long 타입의 PK 가 insert 시 얼마나 빠르게 변경된지 #354 와 비교하여 분석해야합니다.