### PR TITLE
[fix] 친구 없을 때 빈 리스트 반환

### DIFF
--- a/spring-chatting-backend-server/src/main/java/chatting/chat/domain/user/service/UserServiceImpl.java
+++ b/spring-chatting-backend-server/src/main/java/chatting/chat/domain/user/service/UserServiceImpl.java
@@ -65,7 +65,7 @@ public class UserServiceImpl implements UserService {
     public List<FriendResponse.FriendDTO> findAllFriends(String userId) {
         List<Friend> findFriends = friendRepository.findAllByUserId(userId);
         if (findFriends.isEmpty()) {
-            throw new CustomException(CANNOT_FIND_USER);
+            return new ArrayList<>();
         }
         ArrayList<FriendResponse.FriendDTO> collect = findFriends.stream()
             .map(Friend::getFriendId)


### PR DESCRIPTION
* 최초 로그인 시 친구가 없을 때, 빈 리스트를 백엔드서버로부터 반환받을 수 있도록 설정