### PR TITLE
[fix] CacheEvict KEY 빈 내부 ThreadLocal 참조하도록 설정

### DIFF
--- a/spring-chatting-backend-server/src/main/java/chatting/chat/domain/user/service/UserServiceImpl.java
+++ b/spring-chatting-backend-server/src/main/java/chatting/chat/domain/user/service/UserServiceImpl.java
@@ -118,7 +118,7 @@ public class UserServiceImpl implements UserService {
     // 채팅방 생성
     @Override
     @Timed(value = "roomService.makeRoomWithFriends")
-    @CacheEvict(value = "chatRoom", key = "#req.userId")
+    @CacheEvict(value = "chatRoom", key = "@userContext.getUserId()")
     public RoomDto makeRoomWithFriends(RequestAddChatRoomDTO req) throws CustomException {
         ArrayList<UserDto> userParticipants = new ArrayList<>();
 

--- a/spring-chatting-backend-server/src/main/java/chatting/chat/web/filter/UserContext.java
+++ b/spring-chatting-backend-server/src/main/java/chatting/chat/web/filter/UserContext.java
@@ -5,9 +5,10 @@ import com.example.commondto.error.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Configuration
+@Component
 public class UserContext {
 
     private static final ThreadLocal<String> userIdThreadLocal = new ThreadLocal<>();


### PR DESCRIPTION
* 캐시 Write-Around 업데이트 시, CacheEvit 의 key 설정을 변경하였습니다.

UserContext 를 빈으로 등록시키고, 해당 빈의 ThreadLocal 에 저장된 userId 를 가져와 key 로 설정하였습니다.